### PR TITLE
Be08 1/feat/rank

### DIFF
--- a/src/main/java/te/trueEcho/TrueEchoApplication.java
+++ b/src/main/java/te/trueEcho/TrueEchoApplication.java
@@ -4,13 +4,17 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 public class TrueEchoApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(TrueEchoApplication.class, args);
+
 	}
 
 }

--- a/src/main/java/te/trueEcho/domain/rank/controller/RankController.java
+++ b/src/main/java/te/trueEcho/domain/rank/controller/RankController.java
@@ -1,0 +1,32 @@
+package te.trueEcho.domain.rank.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import te.trueEcho.domain.rank.dto.RankListResponse;
+import te.trueEcho.domain.rank.dto.RankResponse;
+import te.trueEcho.domain.rank.service.RankService;
+import te.trueEcho.domain.vote.dto.VoteContentsResponse;
+import te.trueEcho.global.response.ResponseCode;
+import te.trueEcho.global.response.ResponseForm;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/rank")
+public class RankController {
+    private final RankService rankService;
+
+    @GetMapping("/read")
+    public ResponseEntity<ResponseForm> readContent() {
+
+        final RankListResponse rankListResponse = rankService.getRank();
+
+        return rankListResponse != null ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.GET_COMMENT_SUCCESS,rankListResponse)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.GET_COMMENT_FAIL));
+    }
+}

--- a/src/main/java/te/trueEcho/domain/rank/converter/RankToDtoConverter.java
+++ b/src/main/java/te/trueEcho/domain/rank/converter/RankToDtoConverter.java
@@ -1,0 +1,68 @@
+package te.trueEcho.domain.rank.converter;
+
+
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+import te.trueEcho.domain.rank.dto.RankListResponse;
+import te.trueEcho.domain.rank.dto.RankResponse;
+import te.trueEcho.domain.rank.dto.RankUserResponse;
+import te.trueEcho.domain.user.dto.RegisterRequest;
+import te.trueEcho.domain.user.entity.Role;
+import te.trueEcho.domain.user.entity.User;
+import te.trueEcho.domain.vote.entity.Vote;
+import te.trueEcho.domain.vote.entity.VoteResult;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+@Component
+@NoArgsConstructor
+public class RankToDtoConverter {
+
+    public static RankListResponse converter(Map<Vote, Map<User, Integer>> thisWeekRanks) {
+
+        // 모든 랭킹 폼
+        List<RankResponse> rankUserResponses = thisWeekRanks.entrySet().stream()
+                .map(voteUnit -> {
+
+                    Vote vote = voteUnit.getKey();
+                    Map<User, Integer> userVoteCountMap = voteUnit.getValue();
+
+                    // 투표지별
+                    List<RankUserResponse> rankUserResponseList = userVoteCountMap.entrySet().stream()
+                            .map(userUnit -> {
+                                User user = userUnit.getKey();
+                                Integer voteCount = userUnit.getValue();
+
+                                //rank에 있는 각 유저 폼
+                                return RankUserResponse.builder()
+                                        .id(user.getId())
+                                        .nickname(user.getNickname())
+                                        .profileUrl(user.getProfileURL())
+                                        .age(user.getAge()).build();
+                            }).toList();
+
+                    return RankResponse.builder().voteId(vote.getId())
+                            .title(vote.getTitle())
+                            .category(String.valueOf(vote.getCategory()))
+                            .topRankList(rankUserResponseList).build();
+
+                }).toList();
+
+        WeekFields weekFields = WeekFields.of(Locale.getDefault());
+        String thisWeek = LocalDate.now().format(DateTimeFormatter.ofPattern("M월 "))
+                + LocalDate.now().get(weekFields.weekOfMonth()) + "째주";
+
+        return RankListResponse.builder()
+                .thisWeek(thisWeek)
+                .rankList(rankUserResponses)
+                .build();
+    }
+}

--- a/src/main/java/te/trueEcho/domain/rank/converter/RankToDtoConverter.java
+++ b/src/main/java/te/trueEcho/domain/rank/converter/RankToDtoConverter.java
@@ -46,10 +46,14 @@ public class RankToDtoConverter {
                                         .id(user.getId())
                                         .nickname(user.getNickname())
                                         .profileUrl(user.getProfileURL())
-                                        .age(user.getAge()).build();
+                                        .age(user.getAge())
+                                        .voteCount(voteCount)
+                                        .gender(user.getGender().toString())
+                                        .build();
                             }).toList();
 
-                    return RankResponse.builder().voteId(vote.getId())
+                    return RankResponse.builder()
+                            .voteId(vote.getId())
                             .title(vote.getTitle())
                             .category(String.valueOf(vote.getCategory()))
                             .topRankList(rankUserResponseList).build();

--- a/src/main/java/te/trueEcho/domain/rank/dto/RankListResponse.java
+++ b/src/main/java/te/trueEcho/domain/rank/dto/RankListResponse.java
@@ -1,0 +1,15 @@
+package te.trueEcho.domain.rank.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class RankListResponse {
+    private final String thisWeek;
+    private final List<RankResponse> rankList;
+}

--- a/src/main/java/te/trueEcho/domain/rank/dto/RankResponse.java
+++ b/src/main/java/te/trueEcho/domain/rank/dto/RankResponse.java
@@ -1,0 +1,19 @@
+package te.trueEcho.domain.rank.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.catalina.User;
+import te.trueEcho.domain.post.dto.CommentResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Builder
+@Getter
+public class RankResponse {
+    private final Long voteId;
+    private final String title;
+    private final String category;
+    private final List<RankUserResponse> topRankList;
+}

--- a/src/main/java/te/trueEcho/domain/rank/dto/RankUserResponse.java
+++ b/src/main/java/te/trueEcho/domain/rank/dto/RankUserResponse.java
@@ -1,0 +1,16 @@
+package te.trueEcho.domain.rank.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class RankUserResponse {
+    private final Long id;
+    private final String nickname;
+    private final String profileUrl;
+    private final int age;
+    private final String gender;
+    private final int voteCount;
+}

--- a/src/main/java/te/trueEcho/domain/rank/repository/RankRepository.java
+++ b/src/main/java/te/trueEcho/domain/rank/repository/RankRepository.java
@@ -1,0 +1,18 @@
+package te.trueEcho.domain.rank.repository;
+
+
+import te.trueEcho.domain.user.entity.User;
+import te.trueEcho.domain.vote.entity.Vote;
+import te.trueEcho.domain.vote.entity.VoteResult;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoField;
+import java.util.List;
+import java.util.Map;
+
+public interface RankRepository {
+
+     Map<Vote,Map<User, Integer>>  getRanksByWeek();
+
+     void cacheThisWeekRank( Map<Vote,Map<User, Integer>>  voteResultMap);
+}

--- a/src/main/java/te/trueEcho/domain/rank/repository/RankRepository.java
+++ b/src/main/java/te/trueEcho/domain/rank/repository/RankRepository.java
@@ -1,18 +1,12 @@
 package te.trueEcho.domain.rank.repository;
 
 
-import te.trueEcho.domain.user.entity.User;
-import te.trueEcho.domain.vote.entity.Vote;
-import te.trueEcho.domain.vote.entity.VoteResult;
-
-import java.time.LocalDate;
-import java.time.temporal.ChronoField;
-import java.util.List;
-import java.util.Map;
+import te.trueEcho.domain.rank.dto.RankListResponse;
 
 public interface RankRepository {
 
-     Map<Vote,Map<User, Integer>>  getRanksByWeek();
+     RankListResponse getRanksByWeek();
 
-     void cacheThisWeekRank( Map<Vote,Map<User, Integer>>  voteResultMap);
+     void cacheThisWeekRank( RankListResponse voteResultMap);
+
 }

--- a/src/main/java/te/trueEcho/domain/rank/repository/RankRepositoryImpl.java
+++ b/src/main/java/te/trueEcho/domain/rank/repository/RankRepositoryImpl.java
@@ -1,0 +1,74 @@
+package te.trueEcho.domain.rank.repository;
+
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import te.trueEcho.domain.user.entity.User;
+import te.trueEcho.domain.vote.entity.Vote;
+import te.trueEcho.domain.vote.entity.VoteResult;
+import te.trueEcho.domain.vote.repository.VoteType;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoField;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+
+/**
+
+ SELECT rn, VOTE_COUNT, user_id_target, created_at, vote_title, vote_category
+ FROM (
+ SELECT COUNT(VR.user_id_target) AS VOTE_COUNT, VR.user_id_target, MIN(VR.created_at) AS created_at,
+ V.vote_title, V.vote_category,
+ ROW_NUMBER() OVER(PARTITION BY V.vote_title ORDER BY COUNT(VR.user_id_target) DESC, MIN(VR.created_at)) AS rn
+ FROM vote_results VR JOIN votes V
+ ON V.`vote id` = VR.vote_id
+ WHERE WEEK(VR.created_at) = WEEK(NOW())
+ GROUP BY V.vote_title, VR.user_id_target
+ ) subquery
+ WHERE rn <= 3
+ ORDER BY vote_title, VOTE_COUNT DESC, created_at, rn;
+ */
+
+public class RankRepositoryImpl implements RankRepository{
+    private final EntityManager em;
+    private final static ConcurrentHashMap<Integer,  Map<Vote,Map<User, Integer>> > ranksByWeek
+            = new ConcurrentHashMap<>();
+
+    public  Map<Vote,Map<User, Integer>>  getRanksByWeek(){
+        return ranksByWeek.get(getThisWeekAsNum());
+    }
+
+    public void cacheThisWeekRank( Map<Vote,Map<User, Integer>>  voteResultMap){
+        try {
+            resetRank();
+            ranksByWeek.put(getThisWeekAsNum(), voteResultMap);
+        } catch (Exception e) {
+            log.error("Error occurred while caching this week's rank", e);
+        }
+    }
+
+
+    private void resetRankByWeek(int week){
+        ranksByWeek.remove(week);
+    }
+
+    private void resetRank(){
+        ranksByWeek.clear();
+    }
+
+    private int getThisWeekAsNum(){
+        LocalDate now = LocalDate.now();
+        return now.get(ChronoField.ALIGNED_WEEK_OF_YEAR);
+    }
+
+
+}

--- a/src/main/java/te/trueEcho/domain/rank/repository/RankRepositoryImpl.java
+++ b/src/main/java/te/trueEcho/domain/rank/repository/RankRepositoryImpl.java
@@ -2,20 +2,14 @@ package te.trueEcho.domain.rank.repository;
 
 
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
-import te.trueEcho.domain.user.entity.User;
-import te.trueEcho.domain.vote.entity.Vote;
-import te.trueEcho.domain.vote.entity.VoteResult;
-import te.trueEcho.domain.vote.repository.VoteType;
+import te.trueEcho.domain.rank.dto.RankListResponse;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoField;
-import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 
 @Slf4j
@@ -40,14 +34,21 @@ import java.util.stream.Collectors;
 
 public class RankRepositoryImpl implements RankRepository{
     private final EntityManager em;
-    private final static ConcurrentHashMap<Integer,  Map<Vote,Map<User, Integer>> > ranksByWeek
+    private final static ConcurrentHashMap<Integer, RankListResponse> ranksByWeek
             = new ConcurrentHashMap<>();
 
-    public  Map<Vote,Map<User, Integer>>  getRanksByWeek(){
-        return ranksByWeek.get(getThisWeekAsNum());
+    public RankListResponse getRanksByWeek() {
+
+        try {
+            return ranksByWeek.getOrDefault(getThisWeekAsNum(), null);
+
+        }catch (Exception e){
+            log.error("Error occurred while getting rank", e);
+            return null;
+        }
     }
 
-    public void cacheThisWeekRank( Map<Vote,Map<User, Integer>>  voteResultMap){
+    public void cacheThisWeekRank( RankListResponse voteResultMap){
         try {
             resetRank();
             ranksByWeek.put(getThisWeekAsNum(), voteResultMap);

--- a/src/main/java/te/trueEcho/domain/rank/service/RankService.java
+++ b/src/main/java/te/trueEcho/domain/rank/service/RankService.java
@@ -1,0 +1,9 @@
+package te.trueEcho.domain.rank.service;
+
+import te.trueEcho.domain.rank.dto.RankListResponse;
+
+
+public interface  RankService {
+
+    RankListResponse getRank();
+}

--- a/src/main/java/te/trueEcho/domain/rank/service/RankServiceImpl.java
+++ b/src/main/java/te/trueEcho/domain/rank/service/RankServiceImpl.java
@@ -19,8 +19,6 @@ public class RankServiceImpl implements RankService{
 
     @Override
     public RankListResponse getRank() {
-        Map<Vote,Map<User, Integer>>  thisWeekRanks =   rankRepository.getRanksByWeek();
-
-        return RankToDtoConverter.converter(thisWeekRanks);
+        return rankRepository.getRanksByWeek();
     }
 }

--- a/src/main/java/te/trueEcho/domain/rank/service/RankServiceImpl.java
+++ b/src/main/java/te/trueEcho/domain/rank/service/RankServiceImpl.java
@@ -1,0 +1,26 @@
+package te.trueEcho.domain.rank.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import te.trueEcho.domain.rank.converter.RankToDtoConverter;
+import te.trueEcho.domain.rank.dto.RankListResponse;
+import te.trueEcho.domain.rank.repository.RankRepository;
+import te.trueEcho.domain.user.entity.User;
+import te.trueEcho.domain.vote.entity.Vote;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankServiceImpl implements RankService{
+    private final RankRepository rankRepository;
+
+    @Override
+    public RankListResponse getRank() {
+        Map<Vote,Map<User, Integer>>  thisWeekRanks =   rankRepository.getRanksByWeek();
+
+        return RankToDtoConverter.converter(thisWeekRanks);
+    }
+}

--- a/src/main/java/te/trueEcho/domain/rank/service/ScheduledRankService.java
+++ b/src/main/java/te/trueEcho/domain/rank/service/ScheduledRankService.java
@@ -1,11 +1,11 @@
 package te.trueEcho.domain.rank.service;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
+import te.trueEcho.domain.rank.converter.RankToDtoConverter;
 import te.trueEcho.domain.rank.repository.RankRepository;
-import te.trueEcho.domain.rank.repository.RankRepositoryImpl;
 import te.trueEcho.domain.user.entity.User;
 import te.trueEcho.domain.vote.entity.Vote;
 import te.trueEcho.domain.vote.entity.VoteResult;
@@ -58,8 +58,8 @@ public class ScheduledRankService {
     private final VoteRepository voteRepository;
     private final RankRepository rankRepository;
 
-//    @Scheduled(cron = "0 * 20 ? * 0", zone = "Asia/Seoul") //매주 일요일 20시에 랭킹을 만들어주는 서비스
-    @Scheduled(fixedDelay = 10000)
+  @Scheduled(cron = "0 0 20 ? * 0", zone = "Asia/Seoul") //매주 일요일 20시에 랭킹을 만들어주는 서비스
+    @Transactional
     public void makeRank() {
 
         List<VoteResult> voteResults = voteRepository.getThisWeekVoteResult();
@@ -94,10 +94,9 @@ public class ScheduledRankService {
             });
         }
 
-        rankRepository.cacheThisWeekRank(sortedResults); // 이번주 랭킹을 캐싱
+        rankRepository.cacheThisWeekRank(RankToDtoConverter.converter(sortedResults)); // 이번주 랭킹을 캐싱
 
         log.info("Ranking is updated");
-
     }
 }
 

--- a/src/main/java/te/trueEcho/domain/rank/service/ScheduledRankService.java
+++ b/src/main/java/te/trueEcho/domain/rank/service/ScheduledRankService.java
@@ -3,6 +3,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import te.trueEcho.domain.rank.repository.RankRepository;
 import te.trueEcho.domain.rank.repository.RankRepositoryImpl;
 import te.trueEcho.domain.user.entity.User;
@@ -49,13 +50,13 @@ import java.util.stream.Collectors;
         결국 vote로 그룹핑을 하고, 그 vote를 받은 user로 한번 더 그룹핑을 해야 한다.
         그리고 user별로 투표를 받은 횟수를 카운트해야 한다.
          */
-@Component
+@Service
 @Slf4j
 @RequiredArgsConstructor
 public class ScheduledRankService {
 
-    private VoteRepository voteRepository;
-    private RankRepository rankRepository;
+    private final VoteRepository voteRepository;
+    private final RankRepository rankRepository;
 
 //    @Scheduled(cron = "0 * 20 ? * 0", zone = "Asia/Seoul") //매주 일요일 20시에 랭킹을 만들어주는 서비스
     @Scheduled(fixedDelay = 10000)

--- a/src/main/java/te/trueEcho/domain/rank/service/ScheduledRankService.java
+++ b/src/main/java/te/trueEcho/domain/rank/service/ScheduledRankService.java
@@ -1,0 +1,103 @@
+package te.trueEcho.domain.rank.service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import te.trueEcho.domain.rank.repository.RankRepository;
+import te.trueEcho.domain.rank.repository.RankRepositoryImpl;
+import te.trueEcho.domain.user.entity.User;
+import te.trueEcho.domain.vote.entity.Vote;
+import te.trueEcho.domain.vote.entity.VoteResult;
+import te.trueEcho.domain.vote.repository.VoteRepository;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+// 1. 먼저 투표지별로 그룹핑 -> 투표지별 투표를 받은 유저가 그룹핑됨.
+// 2. 1번에서 그룹핑된 결과를 유저별로 그룹핑해야 함. -> 유저별로 투표를 받은 횟수를 카운트할 수 있음
+// 3. 2번에서 그룹핑된 결과를 정렬하여 상위 3명을 선정해야 함.
+
+// 투표지별 그룹핑 -> 투표지별 투표를 받은 유저로 한번 더 그룹핑
+        /* ex)
+        vote1 : { id: 1 , title: "세상에서 가장 멋진 사람", category: "인물" }
+        vote2 : { id: 2 , title: "세상에서 키큰 사람", category: "인물" }
+        user1 : { id: 1, name: "홍길동", nickname: "hong"...}
+        user2 : { id: 2, name: "김철수", nickname: "kim"...}
+        voteResult1 : { id: 1, vote: vote1, userTarget: user1, createdAt: 2021-04-01 }
+        voteResult2 : { id: 2, vote: vote1, userTarget: user1, createdAt: 2021-04-02 }
+        voteResult3 : { id: 3, vote: vote1, userTarget: user2, createdAt: 2021-04-03 }
+        voteResult4 : { id: 4, vote: vote1, userTarget: user2, createdAt: 2021-04-04 }
+
+        {
+            vote1: {
+                user1: [voteResult1, voteResult2,voteResult12,voteResult11]
+                user2: [voteResult3, voteResult4],
+                ...
+            },
+            vote2: {
+                user1: [voteResult5, voteResult6, voteResult9,voteResult10
+                user2: [voteResult7, voteResult8],
+                ...
+            },
+
+        위의 예시를 보면, vote1에 대한 결과를 보면 user1이 4번, user2가 2번 투표를 받았다.
+        그럼 vote1에 대한 랭킹을 부여할 때 user1이 1등, user2가 2등이 되어야 한다.
+        결국 vote로 그룹핑을 하고, 그 vote를 받은 user로 한번 더 그룹핑을 해야 한다.
+        그리고 user별로 투표를 받은 횟수를 카운트해야 한다.
+         */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ScheduledRankService {
+
+    private VoteRepository voteRepository;
+    private RankRepository rankRepository;
+
+//    @Scheduled(cron = "0 * 20 ? * 0", zone = "Asia/Seoul") //매주 일요일 20시에 랭킹을 만들어주는 서비스
+    @Scheduled(fixedDelay = 10000)
+    public void makeRank() {
+
+        List<VoteResult> voteResults = voteRepository.getThisWeekVoteResult();
+
+        Map<Vote, Map<User, List<VoteResult>>> groupedResults = voteResults.stream()
+                .collect(Collectors.groupingBy(VoteResult::getVote,
+                        Collectors.groupingBy(VoteResult::getUserTarget)));
+
+
+        Map<Vote, Map<User, Integer>> sortedResults = new HashMap<>(); // 투표지별로 탑 3명을 선정한 결과를 저장할 맵
+
+        // 각 투표지별 가장 투표를 많이 받은 유저 상위 3명을 선정
+        for (Map.Entry<Vote, Map<User, List<VoteResult>>> entry : groupedResults.entrySet()) { // 투표지 단위 연산
+            Vote vote = entry.getKey();
+            Map<User, List<VoteResult>> userVoteResults = entry.getValue(); // 그 투표지를 받은 유저들의 집합
+
+            List<Map.Entry<User, List<VoteResult>>> sortedUserVoteResults = userVoteResults.entrySet()
+                    .stream()
+                    .sorted(
+                            Comparator.comparing((Map.Entry<User, List<VoteResult>> userVoteResult) ->
+                                            userVoteResult.getValue().size()).reversed() // 투표를 많이 받은 순서
+                                    .thenComparing(userVoteResult ->
+                                            userVoteResult.getValue().get(0).getCreatedAt())) // 더 먼저 투표를 받은 순서로 정렬
+                    .limit(3) // 상위 3명만 선정
+                    .toList();
+
+            sortedUserVoteResults.forEach(userVoteResult -> {
+                User user = userVoteResult.getKey(); // 투표를 받은 유저
+                Integer voteCount = userVoteResult.getValue().size(); // 투표를 받은 횟수
+                sortedResults.putIfAbsent(vote, new HashMap<>());
+                sortedResults.get(vote).put(user, voteCount);
+            });
+        }
+
+        rankRepository.cacheThisWeekRank(sortedResults); // 이번주 랭킹을 캐싱
+
+        log.info("Ranking is updated");
+
+    }
+}
+
+

--- a/src/main/java/te/trueEcho/domain/user/entity/User.java
+++ b/src/main/java/te/trueEcho/domain/user/entity/User.java
@@ -141,6 +141,10 @@ public class User extends CreatedDateAudit {
         this.connectByFriend = true;
     }
 
+    public int getAge(){
+        return LocalDate.now().getYear() - this.birthday.getYear();
+    }
+
     public boolean getNotificationSetting() {
         return this.notificationSetting;
     }

--- a/src/main/java/te/trueEcho/domain/vote/entity/Vote.java
+++ b/src/main/java/te/trueEcho/domain/vote/entity/Vote.java
@@ -15,12 +15,16 @@ import java.util.List;
 public class Vote {
 
     @Id
-    @Column(name = "vote id")
+    @Column(name = "vote_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "vote_title")
     private String title;
+
+    @Column(name = "vote_category")
+    @Enumerated(EnumType.STRING)
+    private VoteCategory category;
 
     @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL)
     private List<VoteResult> voteResults;

--- a/src/main/java/te/trueEcho/domain/vote/entity/VoteCategory.java
+++ b/src/main/java/te/trueEcho/domain/vote/entity/VoteCategory.java
@@ -1,0 +1,27 @@
+package te.trueEcho.domain.vote.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum VoteCategory {
+    PERSONALITY(1),
+
+    INTEREST(2),
+
+    CAREER(3),
+
+    LIFESTYLE(4),
+
+    ROMANCE(5),
+
+    BRAVENESS(6),
+    BIAS(7);
+
+    private final int value;
+}
+
+
+

--- a/src/main/java/te/trueEcho/domain/vote/entity/VoteResult.java
+++ b/src/main/java/te/trueEcho/domain/vote/entity/VoteResult.java
@@ -22,7 +22,6 @@ import te.trueEcho.global.entity.CreatedDateAudit;
                 columnNames={"user_id_target", "user_id_voter", "vote_id"}
         )
 })
-
 public class VoteResult extends CreatedDateAudit {
 
     @Id
@@ -42,14 +41,10 @@ public class VoteResult extends CreatedDateAudit {
     @JoinColumn(name = "vote_id")
     private Vote vote;
 
-    @OneToOne(mappedBy = "voteResult", cascade=CascadeType.ALL)
-    private VoteResultNoti voteResultNoti;
-
     @Builder
-    public VoteResult(User userVoter, User userTarget, Vote vote, VoteResultNoti voteResultNoti) {
+    public VoteResult(User userVoter, User userTarget, Vote vote){
         this.userVoter = userVoter;
         this.userTarget = userTarget;
         this.vote = vote;
-        this.voteResultNoti = voteResultNoti;
     }
 }

--- a/src/main/java/te/trueEcho/domain/vote/repository/VoteRepository.java
+++ b/src/main/java/te/trueEcho/domain/vote/repository/VoteRepository.java
@@ -10,9 +10,12 @@ import java.util.List;
 public interface VoteRepository {
 
      List<Vote> getTodayVoteContentsByType(VoteType type, LocalDate key);
+
      void createSelectedVoteContents();
 
      boolean saveVoteResult(VoteResult result);
 
      Vote findVoteById(Long voteId);
+
+     List<VoteResult> getThisWeekVoteResult();
 }

--- a/src/main/java/te/trueEcho/domain/vote/repository/VoteRepositoryImpl.java
+++ b/src/main/java/te/trueEcho/domain/vote/repository/VoteRepositoryImpl.java
@@ -134,4 +134,15 @@ public class VoteRepositoryImpl implements VoteRepository {
         return randomId;
     }
 
+    public List<VoteResult> getThisWeekVoteResult() {
+        try {
+            //이번주 투표 결과를 가져옴
+            return em.createQuery("SELECT VR FROM VoteResult VR " +
+                            "WHERE WEEK(VR.createdAt) = WEEK(CURRENT_DATE)"
+                    , VoteResult.class).getResultList();
+        } catch (Exception e) {
+            log.error("Error occurred while fetching this week's results", e);
+            return Collections.emptyList();
+        }
+    }
 }

--- a/src/main/java/te/trueEcho/domain/vote/repository/VoteRepositoryImpl.java
+++ b/src/main/java/te/trueEcho/domain/vote/repository/VoteRepositoryImpl.java
@@ -2,6 +2,7 @@ package te.trueEcho.domain.vote.repository;
 
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -136,13 +137,16 @@ public class VoteRepositoryImpl implements VoteRepository {
 
     public List<VoteResult> getThisWeekVoteResult() {
         try {
-            //이번주 투표 결과를 가져옴
             return em.createQuery("SELECT VR FROM VoteResult VR " +
-                            "WHERE WEEK(VR.createdAt) = WEEK(CURRENT_DATE)"
-                    , VoteResult.class).getResultList();
+                            "JOIN FETCH VR.userTarget " +
+                            "JOIN FETCH VR.vote " +
+                            "WHERE FUNCTION('WEEK', VR.createdAt) = :currentWeek", VoteResult.class)
+                    .setParameter("currentWeek", getThisWeekAsNum()-1)
+                    .getResultList();
         } catch (Exception e) {
             log.error("Error occurred while fetching this week's results", e);
             return Collections.emptyList();
         }
     }
+
 }

--- a/src/main/java/te/trueEcho/domain/vote/service/VoteServiceImpl.java
+++ b/src/main/java/te/trueEcho/domain/vote/service/VoteServiceImpl.java
@@ -3,6 +3,7 @@ package te.trueEcho.domain.vote.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import te.trueEcho.domain.post.converter.PostToPhotoDtoConverter;
 import te.trueEcho.domain.post.entity.Post;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class VoteServiceImpl implements VoteService {

--- a/src/main/java/te/trueEcho/global/config/SchedulerConfig.java
+++ b/src/main/java/te/trueEcho/global/config/SchedulerConfig.java
@@ -1,0 +1,22 @@
+package te.trueEcho.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+
+@Configuration
+public class SchedulerConfig implements SchedulingConfigurer {
+    private final int POOL_SIZE = 1; // default 는 1
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        final ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+        threadPoolTaskScheduler.setPoolSize(POOL_SIZE);
+        threadPoolTaskScheduler.setThreadNamePrefix("scheduled-task-pool-");
+        threadPoolTaskScheduler.initialize();
+
+        taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);
+    }
+}

--- a/src/main/java/te/trueEcho/global/response/ResponseCode.java
+++ b/src/main/java/te/trueEcho/global/response/ResponseCode.java
@@ -76,15 +76,18 @@ public enum ResponseCode {
     WRITE_POST_SUCCESS(202, "T002", "게시물 작성을 성공했습니다."),
     WRITE_POST_FAIL(202, "T002", "게시물 작성을 실패했습니다."),
 
-    // 커뮤니티
+
+    // 투표
     GET_VOTE_CONTENT_SUCCESS(202, "T002", "투표지 읽기를 성공했습니다."),
     GET_VOTE_CONTENT_FAIL(202, "T002", "투표지 읽기를 실패했습니다."),
     GET_VOTE_TARGET_SUCCESS(202, "T002", "투표 인원 뽑기를 성공했습니다."),
     GET_VOTE_TARGET_FAIL(202, "T002","투표 인원 뽑기를 실패했습니다."),
     SAVE_VOTE_RESULT_SUCCESS(202, "T002", "투표 결과 저장을 성공했습니다."),
-    SAVE_VOTE_RESULT_FAIL(202, "T002","투표 결과 저장을 실패했습니다.");
+    SAVE_VOTE_RESULT_FAIL(202, "T002","투표 결과 저장을 실패했습니다."),
 
-
+    // 랭킹
+    GET_RANK_SUCCESS(202, "T002", "투표지 읽기를 성공했습니다."),
+    GET_RANK_FAIL(202, "T002", "투표지 읽기를 실패했습니다.");
 
     private final int status;
     private final String code;


### PR DESCRIPTION
Closes #104

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
BE08-1/feat/rank -> back_main

## PR 설명
# 투표 결과에 대한 랭킹 서비스 자동화

## ✅ 완료한 기능 명세
    - 테스트용 더미데이터 추가
    - 투표지에 카테고리 설정
    - 투표지별 랭킹화 → 쿼리 생성
    - 랭킹 WAS 메모리에 캐시
    - 스케줄러 설정
    - 스케줄러를 이용한 랭킹 자동화
    - 클라이언트에서 조회용 엔드 포인트 생성
    - 테스트 

## 2️⃣.BE08-1/feat/rank

- 랭킹화를 위한 더미 데이터 생성
    
![Untitled](https://github.com/TrueEchoProject/TrueEcho_Main/assets/125370420/f0ba2fbd-2f83-47a1-ad00-37c8f7958ac2)

    
- 투표지에 카테고리 설정
    
![Untitled (1)](https://github.com/TrueEchoProject/TrueEcho_Main/assets/125370420/fa00ae0b-5d52-4f65-bb73-f66f28923d3e)

    - 나중에 확장성을 위해 카테고리 설정
    - 카테고리 중에서 하나씩 뽑아서 투표지를 뿌릴 수 있고, 카테고리 별로 랭킹화를 할 수 있음.
    
    ⇒ 뽑는 로직 자체는 아직 위의 변경사항을 반영하지 않음.
    
- 투표지별 랭킹화 → 쿼리 생성
    
    
    - 구현 로직
    
    ```sql
    // 1. 먼저 투표지별로 그룹핑 -> 투표지별 투표를 받은 유저가 그룹핑됨.
    // 2. 1번에서 그룹핑된 결과를 유저별로 그룹핑해야 함. -> 유저별로 투표를 받은 횟수를 카운트할 수 있음
    // 3. 2번에서 그룹핑된 결과를 정렬하여 상위 3명을 선정해야 함.
    
    // 투표지별 그룹핑 -> 투표지별 투표를 받은 유저로 한번 더 그룹핑
            /* ex)
            vote1 : { id: 1 , title: "세상에서 가장 멋진 사람", category: "인물" }
            vote2 : { id: 2 , title: "세상에서 키큰 사람", category: "인물" }
            user1 : { id: 1, name: "홍길동", nickname: "hong"...}
            user2 : { id: 2, name: "김철수", nickname: "kim"...}
            voteResult1 : { id: 1, vote: vote1, userTarget: user1, createdAt: 2021-04-01 }
            voteResult2 : { id: 2, vote: vote1, userTarget: user1, createdAt: 2021-04-02 }
            voteResult3 : { id: 3, vote: vote1, userTarget: user2, createdAt: 2021-04-03 }
            voteResult4 : { id: 4, vote: vote1, userTarget: user2, createdAt: 2021-04-04 }
    
            {
                vote1: {
                    user1: [voteResult1, voteResult2,voteResult12,voteResult11]
                    user2: [voteResult3, voteResult4],
                    ...
                },
                vote2: {
                    user1: [voteResult5, voteResult6, voteResult9,voteResult10
                    user2: [voteResult7, voteResult8],
                    ...
                },
    
            위의 예시를 보면, vote1에 대한 결과를 보면 user1이 4번, user2가 2번 투표를 받았다.
            그럼 vote1에 대한 랭킹을 부여할 때 user1이 1등, user2가 2등이 되어야 한다.
            결국 vote로 그룹핑을 하고, 그 vote를 받은 user로 한번 더 그룹핑을 해야 한다.
            그리고 user별로 투표를 받은 횟수를 카운트해야 한다.
             */
    ```
    
    - 그에 따른 raw 쿼리
    
    ```sql
    
     SELECT rn, VOTE_COUNT, user_id_target, created_at, vote_title, vote_category
     FROM (
    	 SELECT COUNT(VR.user_id_target) AS VOTE_COUNT, VR.user_id_target, MIN(VR.created_at) AS created_at,
    		 V.vote_title, V.vote_category,
    		 ROW_NUMBER() OVER(PARTITION BY V.vote_title ORDER BY COUNT(VR.user_id_target) DESC, MIN(VR.created_at)) AS rn
    	 FROM vote_results VR JOIN votes V
    		 ON V.`vote id` = VR.vote_id
    		 WHERE WEEK(VR.created_at) = WEEK(NOW())
    		 GROUP BY V.vote_title, VR.user_id_target
     ) subquery
     WHERE rn <= 3
     ORDER BY vote_title, VOTE_COUNT DESC, created_at, rn;
    ```
    
    - JPA를 활용해 쿼리를 날리려고 하면, 그 한계가 존재함.
    - 쿼리는 현재 날짜를 기준으로 이번주에 투표된 것을 가져옴.
    - 이후 자바 코드로 랭킹화
    
    ```java
    @Scheduled(cron = "0 0 20 ? * 0", zone = "Asia/Seoul") //매주 일요일 20시에 랭킹을 만들어주는 서비스
        public void makeRank() {
    
            List<VoteResult> voteResults = voteRepository.getThisWeekVoteResult();
    
            Map<Vote, Map<User, List<VoteResult>>> groupedResults = voteResults.stream()
                    .collect(Collectors.groupingBy(VoteResult::getVote,
                            Collectors.groupingBy(VoteResult::getUserTarget)));
    
            Map<Vote, Map<User, Integer>> sortedResults = new HashMap<>(); // 투표지별로 탑 3명을 선정한 결과를 저장할 맵
    
            // 각 투표지별 가장 투표를 많이 받은 유저 상위 3명을 선정
            for (Map.Entry<Vote, Map<User, List<VoteResult>>> entry : groupedResults.entrySet()) { // 투표지 단위 연산
                Vote vote = entry.getKey();
                Map<User, List<VoteResult>> userVoteResults = entry.getValue(); // 그 투표지를 받은 유저들의 집합
    
                List<Map.Entry<User, List<VoteResult>>> sortedUserVoteResults = userVoteResults.entrySet()
                        .stream()
                        .sorted(
                                Comparator.comparing((Map.Entry<User, List<VoteResult>> userVoteResult) ->
                                                userVoteResult.getValue().size()).reversed() // 투표를 많이 받은 순서
                                        .thenComparing(userVoteResult ->
                                                userVoteResult.getValue().get(0).getCreatedAt())) // 더 먼저 투표를 받은 순서로 정렬
                        .limit(3) // 상위 3명만 선정
                        .toList();
    
                sortedUserVoteResults.forEach(userVoteResult -> {
                    User user = userVoteResult.getKey(); // 투표를 받은 유저
                    Integer voteCount = userVoteResult.getValue().size(); // 투표를 받은 횟수
                    sortedResults.putIfAbsent(vote, new HashMap<>());
                    sortedResults.get(vote).put(user, voteCount);
                });
            }
    
            rankRepository.cacheThisWeekRank(sortedResults); // 이번주 랭킹을 캐싱
    
            log.info("Ranking is updated");
        }
    ```
    
- 랭킹 WAS 메모리에 캐시
    
    ```java
    
        private final static ConcurrentHashMap<Integer,  Map<Vote,Map<User, Integer>> > ranksByWeek
                = new ConcurrentHashMap<>();
    
        public  Map<Vote,Map<User, Integer>>  getRanksByWeek(){
            return ranksByWeek.get(getThisWeekAsNum());
        }
    
        public void cacheThisWeekRank( Map<Vote,Map<User, Integer>>  voteResultMap){
            try {
                resetRank();
                ranksByWeek.put(getThisWeekAsNum(), voteResultMap);
            } catch (Exception e) {
                log.error("Error occurred while caching this week's rank", e);
            }
        }
        
        private void resetRankByWeek(int week){
            ranksByWeek.remove(week);
        }
    
        private void resetRank(){
            ranksByWeek.clear();
        }
    
        private int getThisWeekAsNum(){
            LocalDate now = LocalDate.now();
            return now.get(ChronoField.ALIGNED_WEEK_OF_YEAR);
        }
    
    ```
    
- 스케줄러를 이용한 랭킹 자동화
    
![Untitled (2)](https://github.com/TrueEchoProject/TrueEcho_Main/assets/125370420/91fe26b0-be15-4d60-a792-f82ac1ef9fa1)

    
![Untitled (3)](https://github.com/TrueEchoProject/TrueEcho_Main/assets/125370420/ec52b32f-137d-4e35-88ad-d7fded3cf70e)

    - 10초에 한번씩 자동으로 쿼리를 날림.

## 스크린샷

![image](https://github.com/TrueEchoProject/TrueEcho_Main/assets/125370420/3c0ab366-4bf7-448d-b11c-52e1e587eb01)
![image](https://github.com/TrueEchoProject/TrueEcho_Main/assets/125370420/07490c19-47ab-48d4-bf28-a07dbbb0c356)


## 고민과 해결과정
 - 투표 결과로 투표지별 유저 랭킹화를 어떻게 할 수 있을까? 그에 따른 쿼리는 어떻게 나가야 할까?
  --> raw쿼리를 먼저 짜보고, 실제로 쿼리로 랭킹화가 가능한지 확인함. -> 되긴 됨. 
  --> 사실상 쿼리를 날려서 바로 결과를 가져오면, 베스트 (DB 서버로 WAS 부하 분산)
  --> 복잡한 쿼리는 현재 사용하는 방식으로는 어려움을 느낌.
  --> 결론 : 쿼리로는 이번주 랭킹에 사용될 데이터를 모두 불러오고, 이후 데이터 핸들링은 자바 코드로 진행함.
 
 - 투표를 받은 수가 동일해서 등수가 겹치는 경우 랭킹화를 어떻게 할 수 있을까
  --> 투표를 받은 순으로 먼저 하고, 순위가 같을 때는 먼저 투표를 받은 사람을 우선으로 함.
 
- 일주일 단위로 자동 랭킹화를 하는 거라면, 일주일 간 랭킹 페이지(클라이언트)에서 읽어오는 값은 계산된 정적인 데이터인데, DB에서 쿼리를 날려서 가져오는게 비효율적이지 않을까?
  --> WAS 메모리에 캐시함
  --> 현재는 주 단위로 랭킹화 전 캐시된 데이터를 초기화하게 했지만, 주 단위로 삭제할 수 있도록 확장성을 고려해 메소드를 추가함.
  --> redis를 이용해 서버 메모리와 부하를 분산시켜야 할듯. 
 
 - 현재 계산된 랭킹은 클라이언트에서 보기 쉬운 형태(객체)로 되어 있는데, DB에 저장할 때 관계형 테이블 구조에 맞게 다시 풀어서 저장해야 됨. 그리고 나중에 다시 읽을 때 객체화해야 하는데, 너무 비효율적임..
   --> 현재는 WAS 메모리에 캐시하지만, Redis를 활용해 객체 자체를 주자별로 저장하는 것이 더 효율이 좋을 것으로 판단하여 Redis 병행 예정
   
 - 투표 결과에 대한 쿼리를 날리면, 자바 코드로 랭킹화를 위해 VoteResult와 연관관계인 User와 Vote의 내용이 오차피 필요함.    FetchType.LAZY로 인해 프록시로 들고 있다가 나중에 converter내에서 내용을 조회할 때로 쿼리가 계속 나가면 N+1문제가 발생하는데, 어떻게 최적화할까?
  --> 패치 조인해서 한번에 들고 옴.

 - 마찬가지로, VoteResult에는 VoteResultNoti(투표결과에 대한 알림)이 있는데, OneToOne 양방향이라 랭킹화에 필요없는 데이터인데, 그 값을 확인하기 위해 쿼리가 나감. 
   --> 테이블 구조를 단 방향으로 바꿔, VoteResultNoti에서만 조회할 수 있도록 함.
   