### PR TITLE
BE06-3/feat/post-comment-CUD

### DIFF
--- a/src/main/java/te/trueEcho/domain/notification/entity/NotificationEntity.java
+++ b/src/main/java/te/trueEcho/domain/notification/entity/NotificationEntity.java
@@ -21,6 +21,7 @@ import te.trueEcho.global.entity.CreatedDateAudit;
 public class NotificationEntity extends CreatedDateAudit {
 
     @Id
+    @Column(name = "notifications_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -46,8 +47,7 @@ public class NotificationEntity extends CreatedDateAudit {
     @JoinColumn(name = "user_id")
     private User receiver; // 알림의 소유자 (받는 사람)
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "comment_id")
+    @OneToOne(mappedBy = "notificationEntity", cascade= CascadeType.ALL )
     private Comment comment;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/te/trueEcho/domain/post/controller/PostController.java
+++ b/src/main/java/te/trueEcho/domain/post/controller/PostController.java
@@ -1,9 +1,13 @@
 package te.trueEcho.domain.post.controller;
 
+import com.azure.core.annotation.Post;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import te.trueEcho.domain.notification.controller.NotificationController;
+import te.trueEcho.domain.notification.dto.NotiType;
+import te.trueEcho.domain.notification.dto.NotificationDto;
 import te.trueEcho.domain.post.dto.*;
 import te.trueEcho.domain.post.service.PostService;
 import te.trueEcho.global.response.ResponseCode;
@@ -14,6 +18,7 @@ import te.trueEcho.global.response.ResponseForm;
 @RequestMapping("/post")
 public class PostController {
     private final  PostService  postService;
+    private final NotificationController notificationController;
 
     @PostMapping("/write")
     public ResponseEntity<ResponseForm> writePost(
@@ -53,9 +58,20 @@ public class PostController {
                         .build()
         );
 
-        return !postGetDtoList.getReadPostRespons().isEmpty() ?
+        return !postGetDtoList.getReadPostResponse().isEmpty() ?
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.GET_POST_SUCCESS, postGetDtoList)) :
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.GET_POST_FAIL));
+    }
+
+    @DeleteMapping("/delete/{postId}")
+    public ResponseEntity<ResponseForm> deletePost(
+            @PathVariable Long postId){
+
+        boolean isDeleted =  postService.deletePost(postId);
+
+        return isDeleted ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.DELETE_POST_SUCCESS)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.DELETE_POST_FAIL));
     }
 
 
@@ -68,5 +84,39 @@ public class PostController {
         return !commentListResponse.getComments().isEmpty() ?
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.GET_COMMENT_SUCCESS, commentListResponse)) :
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.GET_COMMENT_FAIL));
+    }
+
+    @PostMapping("/write/comment")
+    public ResponseEntity<ResponseForm> writeComment(
+            @RequestBody WriteCommentRequest writeCommentRequest){
+
+        boolean isWritten = postService.writeComment(writeCommentRequest);
+//
+//        if(isWritten){
+//            notificationController.sendNotification(
+//                    NotificationDto.builder().data(
+//                            NotificationDto.Data.builder()
+//                                                .postId(writeCommentRequest.getPostId()) // contentid임.
+//                                                .userId(writeCommentRequest.getReceiverId())
+//                                                .notiType(NotiType.COMMENT.ordinal())
+//                                                .build())
+//                            .build()
+//            );
+//        }
+
+        return isWritten ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.POST_COMMENT_SUCCESS)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.POST_COMMENT_FAIL));
+    }
+
+    @DeleteMapping("/delete/comment/{commentId}")
+    public ResponseEntity<ResponseForm> deleteComment(
+            @PathVariable Long commentId){
+
+        boolean isDeleted = postService.deleteComment(commentId);
+
+        return isDeleted ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.DELETE_COMMENT_SUCCESS)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.DELETE_COMMENT_FAIL));
     }
 }

--- a/src/main/java/te/trueEcho/domain/post/converter/CommentToDto.java
+++ b/src/main/java/te/trueEcho/domain/post/converter/CommentToDto.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 @NoArgsConstructor
 public class CommentToDto {
-    public CommentListResponse converter(List<Comment> commentList, Long postId) {
+    public CommentListResponse converter(List<Comment> commentList, Long postId ,long requestUserId) {
 
         Map<Long, CommentResponse> mainCommentsMap = new HashMap<>();
         List<CommentResponse> commentResponseList = new ArrayList<>();
@@ -22,6 +22,7 @@ public class CommentToDto {
             CommentResponse dto = CommentResponse.builder()
                     .commentId(comment.getId())
                     .content(comment.getContent())
+                    .isMine(comment.getUser().getId()==requestUserId)
                     .userId(comment.getUser().getId())
                     .username(comment.getUser().getName())
                     .profileURL(comment.getUser().getProfileURL())

--- a/src/main/java/te/trueEcho/domain/post/converter/DtoToComment.java
+++ b/src/main/java/te/trueEcho/domain/post/converter/DtoToComment.java
@@ -1,0 +1,23 @@
+package te.trueEcho.domain.post.converter;
+
+
+import lombok.NoArgsConstructor;
+import te.trueEcho.domain.post.dto.WriteCommentRequest;
+import te.trueEcho.domain.post.entity.Comment;
+import te.trueEcho.domain.post.entity.Post;
+import te.trueEcho.domain.user.entity.User;
+
+@NoArgsConstructor
+public class DtoToComment {
+    public Comment converter(WriteCommentRequest writeCommentRequest,
+                             User writer, Post post, Comment parentComment){
+        return Comment.builder()
+                .content(writeCommentRequest.getContent())
+                .post(post)
+                .user(writer)
+                .mainComment(parentComment)
+                .content(writeCommentRequest.getContent())
+                .notificationEntity(null)
+                .build();
+    }
+}

--- a/src/main/java/te/trueEcho/domain/post/converter/PostToDto.java
+++ b/src/main/java/te/trueEcho/domain/post/converter/PostToDto.java
@@ -11,12 +11,13 @@ import java.util.stream.Collectors;
 
 @NoArgsConstructor
 public class PostToDto {
-    public  PostListResponse converter(List<Post> postList, String yourLocation) {
+    public  PostListResponse converter(List<Post> postList, String yourLocation, long userId) {
         List<ReadPostResponse> readPostResponseList = postList.stream()
                 .map(post -> {
                     return ReadPostResponse.builder()
                             .postId(post.getId())
                             .userId(post.getUser().getId())
+                            .isMine(post.getUser().getId()==userId)
                             .title(post.getTitle())
                             .postFrontUrl(post.getUrlFront())
                             .postBackUrl(post.getUrlBack())
@@ -32,7 +33,7 @@ public class PostToDto {
 
         return  PostListResponse.builder()
                 .yourLocation(yourLocation)
-                .readPostRespons(readPostResponseList)
+                .readPostResponse(readPostResponseList)
                 .postCount(readPostResponseList.size()).build();
     }
 }

--- a/src/main/java/te/trueEcho/domain/post/dto/CommentResponse.java
+++ b/src/main/java/te/trueEcho/domain/post/dto/CommentResponse.java
@@ -10,15 +10,16 @@ import java.util.List;
 @Getter
 public class CommentResponse {
    private final Long commentId;
+   private final boolean isMine;
    private final Long userId;
-    private final  String username;
-    private final String profileURL;
-    private final String content;
-    private final LocalDateTime createdAt;
-    private int underCommentCount; //final 아님
-    private final List<CommentResponse> underComments;
+   private final  String username;
+   private final String profileURL;
+   private final String content;
+   private final LocalDateTime createdAt;
+   private int underCommentCount; //final 아님
+   private final List<CommentResponse> underComments;
 
-    public void setUnderComments(int i){
+   public void setUnderComments(int i){
         this.underCommentCount = i;
     }
 }

--- a/src/main/java/te/trueEcho/domain/post/dto/FeedType.java
+++ b/src/main/java/te/trueEcho/domain/post/dto/FeedType.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum FeedType{
 
     FRIEND(0),
-    PUBLIC(1);
+    PUBLIC(1),
+    MINE(2);
 
     private final int value;
 }

--- a/src/main/java/te/trueEcho/domain/post/dto/PostListResponse.java
+++ b/src/main/java/te/trueEcho/domain/post/dto/PostListResponse.java
@@ -11,5 +11,5 @@ import java.util.List;
 public class PostListResponse {
     String yourLocation;
     int postCount;
-    List<ReadPostResponse> readPostRespons;
+    List<ReadPostResponse> readPostResponse;
 }

--- a/src/main/java/te/trueEcho/domain/post/dto/ReadPostResponse.java
+++ b/src/main/java/te/trueEcho/domain/post/dto/ReadPostResponse.java
@@ -10,16 +10,17 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class ReadPostResponse {
-        private String username;
-        private Long userId;
-        private String profileUrl;
-        private Long postId;
-        private String title;
-        private PostStatus status;
-        private int likesCount;
-        private String postFrontUrl;
-        private String postBackUrl;
-        private LocalDateTime createdAt;
-        private int commentCount;
+        private  final String username;
+        private final Long userId;
+        private final boolean isMine;
+        private  final String profileUrl;
+        private final Long postId;
+        private  final String title;
+        private final  PostStatus status;
+        private final int likesCount;
+        private  final String postFrontUrl;
+        private final String postBackUrl;
+        private final LocalDateTime createdAt;
+        private final int commentCount;
     }
 

--- a/src/main/java/te/trueEcho/domain/post/dto/WriteCommentRequest.java
+++ b/src/main/java/te/trueEcho/domain/post/dto/WriteCommentRequest.java
@@ -1,0 +1,16 @@
+package te.trueEcho.domain.post.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import te.trueEcho.domain.notification.dto.NotificationDto;
+
+@Builder
+@Getter
+public class WriteCommentRequest {
+
+    private final Long postId;
+    private final String content;
+    private final Long parentCommentId;
+    private final Long receiverId;
+}

--- a/src/main/java/te/trueEcho/domain/post/entity/Comment.java
+++ b/src/main/java/te/trueEcho/domain/post/entity/Comment.java
@@ -44,14 +44,17 @@ public class Comment extends CreatedDateAudit {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "mainComment", cascade = CascadeType.ALL)
     private List<Comment> subComments = new ArrayList<>();
 
-    @OneToOne(mappedBy = "comment", cascade= CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notifications_id", nullable = true)
     private NotificationEntity notificationEntity;
 
     @Builder
-    public Comment( String content, Post post, User user, NotificationEntity notificationEntity) {
+    public Comment( String content, Post post, User user,
+                    Comment mainComment, NotificationEntity notificationEntity) {
         this.content = content;
         this.post = post;
         this.user = user;
-        this.notificationEntity = notificationEntity;
+        this.mainComment = mainComment;
+      this.notificationEntity = notificationEntity;
     }
 }

--- a/src/main/java/te/trueEcho/domain/post/entity/Post.java
+++ b/src/main/java/te/trueEcho/domain/post/entity/Post.java
@@ -41,17 +41,17 @@ public class Post extends CreatedDateAudit {
     @Enumerated(EnumType.STRING)
     private PostStatus status;
 
-    @OneToOne(mappedBy = "post")
+    @OneToOne(mappedBy = "post",  cascade = CascadeType.ALL)
     private Pin pin;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post",  cascade = CascadeType.ALL)
     private List<Like> likes;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post",  cascade = CascadeType.ALL)
     private List<Comment> comments;
 
     @Builder

--- a/src/main/java/te/trueEcho/domain/post/repository/PostRepository.java
+++ b/src/main/java/te/trueEcho/domain/post/repository/PostRepository.java
@@ -9,7 +9,16 @@ import java.util.List;
 public interface PostRepository {
     List<Post> getAllPost(int pageCount, int index, List<User> filteredUser);
 
+    Post getPostById(Long postId);
+
     List<Comment> readCommentWithUnderComments(Long postId);
+
+    Comment getParentComment(Long commentId);
+
+
+    boolean writeComment(Comment comment);
+    boolean deletePost(Long postId);
+    boolean deleteComment(Long commentId);
 
     void save(Post post);
 

--- a/src/main/java/te/trueEcho/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/te/trueEcho/domain/post/repository/PostRepositoryImpl.java
@@ -33,6 +33,20 @@ public class PostRepositoryImpl implements PostRepository{
                 .getResultList();
     }
 
+    @Override
+    public Post getPostById(Long postId) {
+        try {
+            return em.createQuery("select p from Post p " +
+                            "join fetch p.user " +
+                            "where p.id = :postId", Post.class)
+                    .setParameter("postId", postId)
+                    .getSingleResult();
+        } catch (Exception e) {
+            log.error("getPostById error : {}", e.getMessage());
+            return null;
+        }
+    }
+
     /**
      *
         먼저 그 게시물에 해당하는 메인 댓글을 조회하고,
@@ -52,6 +66,32 @@ public class PostRepositoryImpl implements PostRepository{
                 .getResultList();
     }
 
+    @Override
+    public Comment getParentComment(Long commentId) {
+        try {
+            return em.createQuery("SELECT c FROM Comment c " +
+                            "JOIN FETCH c.user " +
+                            "WHERE c.id = :commentId", Comment.class)
+                    .setParameter("commentId", commentId)
+                    .getSingleResult();
+        } catch (Exception e) {
+            log.error("getParentComment error : {}", e.getMessage());
+            return null;
+
+        }
+    }
+
+    @Override
+    public boolean writeComment(Comment comment) {
+        try {
+            em.persist(comment);
+            return true;
+        } catch (Exception e) {
+            log.error("writeComment error : {}", e.getMessage());
+            return false;
+        }
+    }
+
     @Transactional
     @Override
     public void save(Post post) {
@@ -59,6 +99,36 @@ public class PostRepositoryImpl implements PostRepository{
             em.persist(post);
         } else {
             em.merge(post);
+        }
+    }
+
+    @Transactional
+    public boolean deletePost(Long postId) {
+        try{
+            Post post = em.find(Post.class, postId);
+            if (post != null) {
+                em.remove(post);
+                return true;
+            }
+            return false;
+        } catch (Exception e) {
+            log.error("deletePost error : {}", e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public boolean deleteComment(Long commentId) {
+        try {
+            Comment comment = em.find(Comment.class, commentId);
+            if (comment != null) {
+                em.remove(comment);
+                return true;
+            }
+            return false;
+        } catch (Exception e) {
+            log.error("deleteComment error : {}", e.getMessage());
+            return false;
         }
     }
 

--- a/src/main/java/te/trueEcho/domain/post/service/PostService.java
+++ b/src/main/java/te/trueEcho/domain/post/service/PostService.java
@@ -1,10 +1,7 @@
 package te.trueEcho.domain.post.service;
 
 
-import te.trueEcho.domain.post.dto.AddPostRequest;
-import te.trueEcho.domain.post.dto.CommentListResponse;
-import te.trueEcho.domain.post.dto.ReadPostRequest;
-import te.trueEcho.domain.post.dto.PostListResponse;
+import te.trueEcho.domain.post.dto.*;
 import te.trueEcho.domain.post.entity.Post;
 
 import java.util.List;
@@ -15,6 +12,12 @@ public interface PostService {
     PostListResponse getAllPostByType(ReadPostRequest readPostRequest);
 
     CommentListResponse getComment(Long postId);
+
+    boolean writeComment(WriteCommentRequest writeCommentRequest);
+
+    boolean deleteComment(Long commentId);
+
+    boolean deletePost(Long postId);
 
     boolean writePost(AddPostRequest addPostRequest);
 }

--- a/src/main/java/te/trueEcho/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/te/trueEcho/domain/post/service/PostServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import te.trueEcho.domain.friend.repository.FriendRepositoryImpl;
 import te.trueEcho.domain.post.converter.CommentToDto;
+import te.trueEcho.domain.post.converter.DtoToComment;
 import te.trueEcho.domain.post.converter.PostToDto;
 import te.trueEcho.domain.post.dto.*;
 import te.trueEcho.domain.post.entity.Comment;
@@ -18,6 +19,7 @@ import te.trueEcho.domain.user.repository.UserRepository;
 import te.trueEcho.global.util.AuthUtil;
 import te.trueEcho.infra.azure.AzureUploader;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static te.trueEcho.domain.post.entity.PostStatus.fromValue;
@@ -34,26 +36,38 @@ public class PostServiceImpl implements PostService {
     private final AzureUploader azureUploader;
     private final PostToDto postToDto;
     private  final CommentToDto commentToDto;
+    private final DtoToComment dtoToComment;
 
     @Override
     public PostListResponse getAllPostByType(ReadPostRequest readPostRequest) {
         // 요청자의 위치
         User foundUser = authUtil.getLoginUser();
+        log.warn("foundUser: {}", foundUser.getId());
         String yourLocation = foundUser.getLocation();
 
         // 필터링하는 위치 [ default -> all ]
         String filterLocation = getFilterLocation(readPostRequest);
 
         // 게시물 조회
-        List<User> filteredUser =
-                readPostRequest.getType() == FeedType.FRIEND ?
-                        friendRepository.findMyFriendsByUser(foundUser) :
-                        userRepository.findUsersByLocation(filterLocation, foundUser);
+        List<User> filteredUser = new ArrayList<>();
+
+        switch (readPostRequest.getType()){
+            case FRIEND:
+                filteredUser =  friendRepository.findMyFriendsByUser(foundUser);
+                break;
+            case PUBLIC:
+                filteredUser =  userRepository.findUsersByLocation(filterLocation, foundUser);
+                break;
+            case MINE:
+                filteredUser.add(foundUser);
+                break;
+            default:
+                log.error("Invalid feed type: {}", readPostRequest.getType());
+        }
 
         List<Post> postList = postRepository.getAllPost(readPostRequest.getPageCount(), readPostRequest.getIndex(), filteredUser);
-
         // post -> Dto 컨버터
-        return postToDto.converter(postList, yourLocation);
+        return postToDto.converter(postList, yourLocation,foundUser.getId());
     }
 
 
@@ -66,8 +80,42 @@ public class PostServiceImpl implements PostService {
     @Override
     public CommentListResponse getComment(Long postId) {
         List<Comment> comments = postRepository.readCommentWithUnderComments(postId);
+        User user = authUtil.getLoginUser();
+        return commentToDto.converter(comments, postId, user.getId());
+    }
 
-        return commentToDto.converter(comments, postId);
+    @Override
+    @Transactional
+    public boolean writeComment(WriteCommentRequest writeCommentRequest) {
+        User loginUser = authUtil.getLoginUser();
+        if (loginUser == null) {
+            log.error("Authentication failed - No login user found");
+            return false;
+        }
+
+        Comment mainComment = null;
+        Post commentedPost = null;
+
+        if (writeCommentRequest.getParentCommentId() != null) {
+            mainComment = postRepository.getParentComment(writeCommentRequest.getParentCommentId());
+            commentedPost = mainComment.getPost();
+        }else{
+            commentedPost = postRepository.getPostById(writeCommentRequest.getPostId());
+        }
+
+        Comment newComment = dtoToComment.converter(writeCommentRequest, loginUser, commentedPost, mainComment);
+        return postRepository.writeComment(newComment);
+    }
+
+    @Override
+    public boolean deleteComment(Long commentId) {
+        return postRepository.deleteComment(commentId);
+    }
+
+    @Override
+    public boolean deletePost(Long postId) {
+        return postRepository.deletePost(postId);
+
     }
 
     @Override

--- a/src/main/java/te/trueEcho/domain/setting/controller/SettingController.java
+++ b/src/main/java/te/trueEcho/domain/setting/controller/SettingController.java
@@ -148,11 +148,10 @@ public class SettingController {
 
     @PatchMapping("/notifyTime")
     public ResponseEntity<ResponseForm> editNotifyTime(@RequestParam int editTime) {
-
         RandomNotifyTResponse randomNotifyTResponse = settingService.getRandomNotifyTime();
         return randomNotifyTResponse != null ?
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.GET_NOTIFY_TIME_SUCCESS, randomNotifyTResponse)) :
-                ResponseEntity.ok(ResponseForm.of(ResponseCode.GET_NOTIFY_TIME_FAIL));
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.PUT_NOTIFY_TIME_SUCCESS, randomNotifyTResponse)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.PUT_NOTIFY_TIME_SUCCESS));
     }
 
     @GetMapping("/notifyTime")

--- a/src/main/java/te/trueEcho/domain/setting/dto/mypage/OtherPageResponse.java
+++ b/src/main/java/te/trueEcho/domain/setting/dto/mypage/OtherPageResponse.java
@@ -9,6 +9,6 @@ import te.trueEcho.domain.setting.dto.pin.PinListResponse;
 public class OtherPageResponse {
     private final Long userId;
     private final MyPageResponse pageInfo;
-    private boolean isFriend;
+    private final boolean isFriend;
     private final PinListResponse pinList;
 }

--- a/src/main/java/te/trueEcho/global/config/UtilConfig.java
+++ b/src/main/java/te/trueEcho/global/config/UtilConfig.java
@@ -3,13 +3,13 @@ package te.trueEcho.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import te.trueEcho.domain.post.converter.CommentToDto;
+import te.trueEcho.domain.post.converter.DtoToComment;
 import te.trueEcho.domain.post.converter.PostToDto;
 import te.trueEcho.domain.rank.converter.RankToDto;
 import te.trueEcho.domain.setting.converter.NotificationSettingToDto;
 import te.trueEcho.domain.setting.converter.PinListToDto;
 import te.trueEcho.domain.setting.converter.PostListToDto;
 import te.trueEcho.domain.setting.converter.UserPinToDto;
-import te.trueEcho.domain.setting.dto.mypage.OtherPageResponse;
 import te.trueEcho.domain.user.converter.SignUpDtoToUser;
 import te.trueEcho.domain.vote.converter.VoteToDto;
 import te.trueEcho.domain.vote.converter.VoteUserToDto;
@@ -20,7 +20,7 @@ public class UtilConfig {
     public SignUpDtoToUser signUpDtoToUserConverter() {return new SignUpDtoToUser();   }
 
     @Bean
-    public VoteToDto voteToDtoConverter() {
+    public VoteToDto voteToDto() {
         return new VoteToDto();
     }
 
@@ -29,27 +29,27 @@ public class UtilConfig {
     }
 
     @Bean
-    public PostToDto postToDtoConverter() {
+    public PostToDto postToDto() {
         return new PostToDto();
     }
 
     @Bean
-    public CommentToDto commentToDtoConverter() {
+    public CommentToDto commentToDto() {
         return new CommentToDto();
     }
 
     @Bean
-    public RankToDto rankToDtoConverter() {
+    public RankToDto rankToDto() {
         return new RankToDto();
     }
 
     @Bean
-    public PinListToDto pinListToDtoConverter() {
+    public PinListToDto pinListToDto() {
         return new PinListToDto();
     }
 
     @Bean
-    public PostListToDto postListToDtoConverter() {
+    public PostListToDto postListToDto() {
         return new PostListToDto();
     }
 
@@ -58,7 +58,12 @@ public class UtilConfig {
         return new NotificationSettingToDto();
     }
     @Bean
-    public UserPinToDto otherPageResponse() {
+    public UserPinToDto userPinToDto() {
         return new UserPinToDto();
+    }
+
+    @Bean
+    public DtoToComment dtoToComment() {
+        return new DtoToComment();
     }
 }

--- a/src/main/java/te/trueEcho/global/response/ResponseCode.java
+++ b/src/main/java/te/trueEcho/global/response/ResponseCode.java
@@ -71,10 +71,18 @@ public enum ResponseCode {
     // 게시물
     GET_POST_SUCCESS(202, "T002", "게시물을 조회를 성공했습니다."),
     GET_POST_FAIL(202, "T002", "게시물을 조회를 실패했습니다."),
-    GET_COMMENT_SUCCESS(202, "T002", "해당 게시물의 댓글 조회를 성공했습니다."),
-    GET_COMMENT_FAIL(202, "T002", "해당 게시물의 댓글 조회를 실패했습니다."),
     WRITE_POST_SUCCESS(202, "T002", "게시물 작성을 성공했습니다."),
     WRITE_POST_FAIL(202, "T002", "게시물 작성을 실패했습니다."),
+    DELETE_POST_SUCCESS(202, "T002", "게시물을 삭제를 성공했습니다."),
+    DELETE_POST_FAIL(202, "T002", "게시물을 삭제를 실패했습니다."),
+    // 댓글
+    GET_COMMENT_SUCCESS(202, "T002", "해당 게시물의 댓글 조회를 성공했습니다."),
+    GET_COMMENT_FAIL(202, "T002", "해당 게시물의 댓글 조회를 실패했습니다."),
+    POST_COMMENT_SUCCESS(202, "T002", "해당 게시물의 댓글 생성을 성공했습니다."),
+    POST_COMMENT_FAIL(202, "T002", "해당 게시물의 댓글 생성을 실패했습니다."),
+    DELETE_COMMENT_SUCCESS(202, "T002", "댓글 삭제를 성공했습니다."),
+    DELETE_COMMENT_FAIL(202, "T002", "댓글 삭제를 실패했습니다."),
+
 
 
     // 투표


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
BE06-3/feat/post-comment-CUD -> back_main

## PR 설명

아래와 같은 기능을 추가, 변경

- 알림시간 변경
- 게시물 
- 댓글

## ✅ 완료한 기능 명세

- [x] 알림 시간 변경 핸들링
- [x] 나의 게시물 조회 엔드포인트
- [x] 나의 게시물 삭제
- [x] 댓글 생성
- [x] 댓글 삭제

## 📸 스크린샷


## 고민과 해결과정
## 알림시간 변경 핸들링
- 현재 알림수정을 요청한 유저가 오늘을 기준으로 랜덤 알림을 받았는지를 확인해야 한다.
- 알림을 받지도 않았는데, 이전 시간으로 변경을 요청하면, 오늘 알림을 받지 못하는 경우가 생기기 때문이다.
- ex) 오후 3시에 알림을 받아야 하는 유저가 오후 2시 50분에 알림 수정( 오전 11시로 )을 요청 -> 수정 권한을 바로 주면, 그날은 알림을 받지 못한다.

- 따라서 다음과 같은 절차로 해결

-  알림시간 변경에 대한 요청받기
- 요청한 유저가 오늘 알림 받았는지 확인하기
- 알림을 받았으면, 수정할 수 있는 권한을 주지만, 7시간(서비스에서 가장 긴 알람 텀)을 기다린 뒤에 수정시킴.
- 알림을 받지 못했으면, 알림을 받을 때까지 waitMap에 (메모리)저장 -> 아직 권한이 없음
- 랜덤알림을 a에게 보낼 때 waitMap에  a가 있는지 확인 -> 있으면 권한을 부여
- 권한 부여를 받은 유저는 waitQueue로 이동하여 7시간 뒤에 순차적으로 알림을 수정 