### PR TITLE
BE/feat/post/response

### DIFF
--- a/src/main/java/te/trueEcho/domain/post/controller/PostController.java
+++ b/src/main/java/te/trueEcho/domain/post/controller/PostController.java
@@ -15,7 +15,7 @@ import te.trueEcho.domain.post.entity.PostStatus;
 import te.trueEcho.domain.post.service.PostService;
 import te.trueEcho.global.response.ResponseCode;
 import te.trueEcho.global.response.ResponseForm;
-
+import te.trueEcho.global.response.ResponseInterface;
 
 
 @Tag(name = "Post API", description = "게시물 관리 API")
@@ -70,7 +70,7 @@ public class PostController {
     @GetMapping("/read")
     public ResponseEntity<ResponseForm> readSinglePost(@RequestParam Long postId){
 
-        ReadPostResponse postGetDtoList =  postService.getSinglePost(postId);
+        ResponseInterface postGetDtoList =  postService.getSinglePost(postId);
 
         return  postGetDtoList != null ?
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.GET_POST_SUCCESS, postGetDtoList)) :
@@ -184,18 +184,6 @@ public class PostController {
             @RequestBody WriteCommentRequest writeCommentRequest){
 
         boolean isWritten = postService.writeComment(writeCommentRequest);
-//
-//        if(isWritten){
-//            notificationController.sendNotification(
-//                    NotificationDto.builder().data(
-//                            NotificationDto.Data.builder()
-//                                                .postId(writeCommentRequest.getPostId()) // contentid임.
-//                                                .userId(writeCommentRequest.getReceiverId())
-//                                                .notiType(NotiType.COMMENT.ordinal())
-//                                                .build())
-//                            .build()
-//            );
-//        }
 
         return isWritten ?
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.POST_COMMENT_SUCCESS)) :

--- a/src/main/java/te/trueEcho/domain/post/converter/PostToDto.java
+++ b/src/main/java/te/trueEcho/domain/post/converter/PostToDto.java
@@ -2,12 +2,16 @@ package te.trueEcho.domain.post.converter;
 
 import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
+import te.trueEcho.domain.friend.entity.Friend;
+import te.trueEcho.domain.post.dto.FeedType;
 import te.trueEcho.domain.post.dto.ReadPostResponse;
 import te.trueEcho.domain.post.dto.PostListResponse;
 import te.trueEcho.domain.post.entity.Post;
+import te.trueEcho.domain.user.entity.User;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @NoArgsConstructor
@@ -15,29 +19,44 @@ public class PostToDto {
     public  PostListResponse converter(List<Post> postList,
                                        String yourLocation,
                                        Long userId,
-                                       boolean isFriend) {
+                                       FeedType feedType,
+                                       List<User> friendGroup) {
         List<ReadPostResponse> readPostResponseList = postList.stream()
-                .map(post -> {
-                    return ReadPostResponse.builder()
-                            .postId(post.getId())
-                            .userId(post.getUser().getId())
-                            .isMine(Objects.equals(post.getUser().getId(), userId))
-                            .isFriend(isFriend)
-                            .title(post.getTitle())
-                            .postFrontUrl(post.getUrlFront())
-                            .postBackUrl(post.getUrlBack())
-                            .commentCount(post.getLikes().size())
-                            .status(post.getStatus())
-                            .username(post.getUser().getName())
-                            .profileUrl(post.getUser().getProfileURL())
-                            .createdAt(post.getCreatedAt())
-                            .isMyLike(
-                                    post.getLikes().stream().anyMatch(
-                                            like -> like.getUser().getId().equals(userId)
-                                    )
-                            )
-                            .build();
-                })
+                .map(post -> ReadPostResponse.builder()
+                        .postId(post.getId())
+                        .userId(post.getUser().getId())
+                        .profileUrl(post.getUser().getProfileURL())
+                        .username(post.getUser().getName())
+                        .isMine(Objects.equals(post.getUser().getId(), userId))
+                        .isFriend(
+                               switch(feedType) {
+                                    case FRIEND -> true;
+                                    case PUBLIC -> friendGroup.stream().anyMatch(
+                                             friend -> Optional.ofNullable(friend)
+                                                     .map(user -> user.equals(post.getUser()))
+                                                     .orElse(false)
+                                     ) || friendGroup.stream().anyMatch(
+                                             friend -> Optional.ofNullable(friend)
+                                                     .map(user -> user.equals(post.getUser()))
+                                                     .orElse(false)
+                                     );
+                                    case MINE -> true;
+                                }
+                        )
+                        .isMyLike(
+                                post.getLikes().stream().anyMatch(
+                                        like -> like.getUser().getId().equals(userId)
+                                )
+                        )
+                        .title(post.getTitle())
+                        .postFrontUrl(post.getUrlFront())
+                        .postBackUrl(post.getUrlBack())
+                        .commentCount(post.getComments().size())
+                        .likesCount(post.getLikes().size())
+                        .status(post.getStatus())
+                        .createdAt(post.getCreatedAt())
+                        .build()
+                )
                 .collect(Collectors.toList());
 
 

--- a/src/main/java/te/trueEcho/domain/post/dto/ReadPostResponse.java
+++ b/src/main/java/te/trueEcho/domain/post/dto/ReadPostResponse.java
@@ -3,13 +3,14 @@ package te.trueEcho.domain.post.dto;
 import lombok.Builder;
 import lombok.Getter;
 import te.trueEcho.domain.post.entity.PostStatus;
+import te.trueEcho.global.response.ResponseInterface;
 
 import java.time.LocalDateTime;
 
 
 @Getter
 @Builder
-public class ReadPostResponse {
+public class ReadPostResponse implements ResponseInterface {
         private  final String username;
         private final Long userId;
         private final boolean isMine;

--- a/src/main/java/te/trueEcho/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/te/trueEcho/domain/post/repository/PostRepositoryImpl.java
@@ -44,6 +44,7 @@ public class PostRepositoryImpl implements PostRepository {
         try {
             return em.createQuery("select p from Post p " +
                             "join fetch p.user " +
+                            "left join fetch p.likes " +
                             "where p.id = :postId", Post.class)
                     .setParameter("postId", postId)
                     .getSingleResult();

--- a/src/main/java/te/trueEcho/domain/post/service/PostService.java
+++ b/src/main/java/te/trueEcho/domain/post/service/PostService.java
@@ -5,13 +5,14 @@ import org.hibernate.sql.Update;
 import te.trueEcho.domain.post.dto.*;
 import te.trueEcho.domain.post.entity.Post;
 import te.trueEcho.domain.post.entity.PostStatus;
+import te.trueEcho.global.response.ResponseInterface;
 
 import java.util.List;
 
 
 public interface PostService {
 
-    ReadPostResponse  getSinglePost(Long postId);
+    ResponseInterface getSinglePost(Long postId);
 
     PostListResponse getAllPostByType(ReadPostRequest readPostRequest);
 

--- a/src/main/java/te/trueEcho/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/te/trueEcho/domain/post/service/PostServiceImpl.java
@@ -69,7 +69,7 @@ public class PostServiceImpl implements PostService {
         }
 
         return ReadPostResponse.builder()
-                .isMine(targetPost.getUser() != requestUser)
+                .isMine(targetPost.getUser().equals(requestUser))
                 .postFrontUrl(targetPost.getUrlFront())
                 .postBackUrl(targetPost.getUrlBack())
                 .createdAt(targetPost.getCreatedAt())

--- a/src/main/java/te/trueEcho/domain/setting/controller/SettingController.java
+++ b/src/main/java/te/trueEcho/domain/setting/controller/SettingController.java
@@ -156,14 +156,6 @@ public class SettingController {
                                                        @RequestParam(required = false) Double x,
                                                        @RequestParam(required = false) Double y) {
 
-        boolean isDuplicated =  userAuthService.isTypeDuplicated(
-                UserCheckRequest.builder()
-                        .nickname(nickname)
-                        .build(), ValidationType.NICKNAME);
-
-        if (isDuplicated){
-            return ResponseEntity.ok(ResponseForm.of(ResponseCode.NOT_DUPLICATED_FAIL));
-        }
 
         boolean isEdited =  settingService.editMyInfo(EditMyInfoRequest.builder()
                 .profileImage(profileImage)

--- a/src/main/java/te/trueEcho/domain/user/controller/UserAuthController.java
+++ b/src/main/java/te/trueEcho/domain/user/controller/UserAuthController.java
@@ -152,6 +152,18 @@ public class UserAuthController {
     @PatchMapping("/password")
     public ResponseEntity<ResponseForm> updatePassword(
             @RequestBody UpdatePasswordRequest registerRequest) {
+
+        boolean isVerified = userAuthService.checkEmailCode(
+                CheckCodeRequest.builder()
+                        .email(registerRequest.getEmail())
+                        .checkCode(registerRequest.getVerificationCode())
+                        .build()
+        );
+
+        if (!isVerified) {
+            return ResponseEntity.ok(ResponseForm.of(VERIFY_EMAIL_FAIL));
+        }
+
         final boolean isUpdated = userAuthService.updatePassword(registerRequest);
 
         return isUpdated ?

--- a/src/main/java/te/trueEcho/domain/user/dto/UpdatePasswordRequest.java
+++ b/src/main/java/te/trueEcho/domain/user/dto/UpdatePasswordRequest.java
@@ -12,6 +12,9 @@ public class UpdatePasswordRequest {
     @Schema(description = "이메일", example = "trueEcho@gmail.com", required = true)
     private final String email;
 
+    @Schema(description = "인증코드", example = "123456", required = true)
+    private final String verificationCode;
+
     @Schema(description = "새 비밀번호", example = "newSecurePassword123!", required = true)
     private final String newPassword;
 }

--- a/src/main/java/te/trueEcho/domain/user/entity/User.java
+++ b/src/main/java/te/trueEcho/domain/user/entity/User.java
@@ -88,10 +88,10 @@ public class User extends CreatedDateAudit {
     private String fcmToken;
 
     @OneToMany(mappedBy = "sendUser", cascade = CascadeType.ALL)
-    private List<Friend> friend;
+    private List<Friend> friend = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private List<Block> block;
+    private List<Block> blockedUsers = new ArrayList<>();
 
 //    @OneToOne(mappedBy = "user",  cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 //    private SuspendedUser suspendedUser;

--- a/src/main/java/te/trueEcho/global/response/ExceptionResponse.java
+++ b/src/main/java/te/trueEcho/global/response/ExceptionResponse.java
@@ -1,0 +1,12 @@
+package te.trueEcho.global.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+public class ExceptionResponse implements ResponseInterface {
+    private final String exceptionMessage;
+    private final String exceptionCode;
+}

--- a/src/main/java/te/trueEcho/global/response/ResponseInterface.java
+++ b/src/main/java/te/trueEcho/global/response/ResponseInterface.java
@@ -1,0 +1,4 @@
+package te.trueEcho.global.response;
+
+public interface ResponseInterface {
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

BE/feat/post/response -> back_main

## PR 설명

기타 에러 수정 및 로직 강화

## ✅ 완료한 기능 명세


### - [x] 게시물 응답 json - friend 수정
- 내 자신의 게시물에는 모두 friend를 true 값으로 반환

### - [x] 마이페이지 개인정보 수정시 닉네임 중복 로직 제거
- myinfo 수정 시, 닉네임 변경이 포함되지 않은 변경일 수 있기에 정보 수정에서는 사용자 이름 중복 여부 파악하는 로직 제거 필요.

### - [x] 비밀번호 변경 로직 강화
- 비밀번호를 변경하고자 할 때 본인을 인증하는 특별한 로직이 없음
- 비밀번호 변경 대상자가 본인인지를 이메일 인증 등으로 파악.

### - [x] 단일 게시물 조회시 mine 필드 반환 
- 누락되어있던 필드를 채움.

### - [x] 차단했거나, 탈퇴한 유저들의 게시물 필터링
- 조건에 해당하는 유저들을 제외한 게시물 출

### - [x] 친구상태 필드 오류 수정(게시물, 마이페이지)
- 친구상태를 나타내는 필드가 부정확함 -> 정적으로 판단했음
- 공개피드에서 조회시 각 게시물 별로 친구인지 여부를 판단해서 반환
- 자기 자신의 게시물에서는 이 필드가 항상 true가 되도록 함.


