### PR TITLE
feat : 이미지 블러처리 기능 (PostedIn24H)

### DIFF
--- a/src/main/java/te/trueEcho/domain/post/controller/PostController.java
+++ b/src/main/java/te/trueEcho/domain/post/controller/PostController.java
@@ -68,9 +68,15 @@ public class PostController {
             @ApiResponse(responseCode = "400", description = "GET_POST_FAIL - 게시물 조회 실패")
     })
     @GetMapping("/read")
-    public ResponseEntity<ResponseForm> readSinglePost(@RequestParam Long postId){
+    public ResponseEntity<ResponseForm> readSinglePost(@RequestParam Long postId,
+                                                       @RequestParam(required = false) boolean requireRefresh){
 
-        ResponseInterface postGetDtoList =  postService.getSinglePost(postId);
+        ResponseInterface postGetDtoList =
+                postService.getSinglePost(SinglePostRequest.builder()
+                                                            .postId(postId)
+                                                            .requireRefresh(requireRefresh)
+                                                            .build()
+                                        );
 
         return  postGetDtoList != null ?
                 ResponseEntity.ok(ResponseForm.of(ResponseCode.GET_POST_SUCCESS, postGetDtoList)) :
@@ -94,7 +100,8 @@ public class PostController {
             @PathVariable int type,
             @RequestParam(required = false) String location,
             @RequestParam int index,
-            @RequestParam int pageCount){
+            @RequestParam int pageCount,
+            @RequestParam(required = false) boolean requireRefresh){
 
         PostListResponse postGetDtoList =  postService.getAllPostByType(
                 ReadPostRequest.builder()
@@ -102,6 +109,7 @@ public class PostController {
                         .pageCount(pageCount)
                         .type(FeedType.values()[type])
                         .location(location)
+                        .requireRefresh(requireRefresh)
                         .build()
         );
 

--- a/src/main/java/te/trueEcho/domain/post/converter/PostToDto.java
+++ b/src/main/java/te/trueEcho/domain/post/converter/PostToDto.java
@@ -4,6 +4,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
 import te.trueEcho.domain.friend.entity.Friend;
 import te.trueEcho.domain.post.dto.FeedType;
+import te.trueEcho.domain.post.dto.PostedIn24H;
 import te.trueEcho.domain.post.dto.ReadPostResponse;
 import te.trueEcho.domain.post.dto.PostListResponse;
 import te.trueEcho.domain.post.entity.Post;
@@ -20,7 +21,8 @@ public class PostToDto {
                                        String yourLocation,
                                        Long userId,
                                        FeedType feedType,
-                                       List<User> friendGroup) {
+                                       List<User> friendGroup,
+                                       PostedIn24H postedIn24H) {
         List<ReadPostResponse> readPostResponseList = postList.stream()
                 .map(post -> ReadPostResponse.builder()
                         .postId(post.getId())
@@ -63,6 +65,8 @@ public class PostToDto {
         return  PostListResponse.builder()
                 .yourLocation(yourLocation)
                 .readPostResponse(readPostResponseList)
-                .postCount(readPostResponseList.size()).build();
+                .postCount(readPostResponseList.size())
+                .postedIn24H(postedIn24H)
+                .build();
     }
 }

--- a/src/main/java/te/trueEcho/domain/post/dto/PostListResponse.java
+++ b/src/main/java/te/trueEcho/domain/post/dto/PostListResponse.java
@@ -9,7 +9,8 @@ import java.util.List;
 @Getter
 @Builder
 public class PostListResponse {
-    String yourLocation;
-    int postCount;
-    List<ReadPostResponse> readPostResponse;
+    private final String yourLocation;
+    private final int postCount;
+    private final List<ReadPostResponse> readPostResponse;
+    private final PostedIn24H postedIn24H;
 }

--- a/src/main/java/te/trueEcho/domain/post/dto/PostedIn24H.java
+++ b/src/main/java/te/trueEcho/domain/post/dto/PostedIn24H.java
@@ -1,0 +1,14 @@
+package te.trueEcho.domain.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class PostedIn24H {
+    private final boolean postedFront;
+    private final boolean postedBack;
+    private final LocalDateTime postedAt;
+}

--- a/src/main/java/te/trueEcho/domain/post/dto/ReadPostRequest.java
+++ b/src/main/java/te/trueEcho/domain/post/dto/ReadPostRequest.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ReadPostRequest {
-    private int pageCount;
-    private int index;
-    private String location;
-    private FeedType type;
-
+    private final int pageCount;
+    private final int index;
+    private final String location;
+    private final FeedType type;
+    private final boolean requireRefresh;
 }
 
 

--- a/src/main/java/te/trueEcho/domain/post/dto/ReadPostResponse.java
+++ b/src/main/java/te/trueEcho/domain/post/dto/ReadPostResponse.java
@@ -25,5 +25,6 @@ public class ReadPostResponse implements ResponseInterface {
         private final int commentCount;
         private final boolean isFriend;
         private final boolean isMyLike;
+        private final PostedIn24H postedIn24H;
     }
 

--- a/src/main/java/te/trueEcho/domain/post/dto/SinglePostRequest.java
+++ b/src/main/java/te/trueEcho/domain/post/dto/SinglePostRequest.java
@@ -1,0 +1,12 @@
+package te.trueEcho.domain.post.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SinglePostRequest {
+    private final Long postId;
+    private final boolean requireRefresh;
+}

--- a/src/main/java/te/trueEcho/domain/post/repository/PostRepository.java
+++ b/src/main/java/te/trueEcho/domain/post/repository/PostRepository.java
@@ -12,7 +12,7 @@ public interface PostRepository {
     List<Post> getAllPost(int pageCount, int index, List<User> filteredUser);
 
     Post getPostById(Long postId);
-
+    Post getLatestPostByUser(User user);
     List<Comment> readCommentWithUnderComments(Long postId);
 
 

--- a/src/main/java/te/trueEcho/domain/post/service/PostService.java
+++ b/src/main/java/te/trueEcho/domain/post/service/PostService.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public interface PostService {
 
-    ResponseInterface getSinglePost(Long postId);
+    ResponseInterface getSinglePost(SinglePostRequest singlePostRequest);
 
     PostListResponse getAllPostByType(ReadPostRequest readPostRequest);
 

--- a/src/main/java/te/trueEcho/domain/vote/service/VoteServiceImpl.java
+++ b/src/main/java/te/trueEcho/domain/vote/service/VoteServiceImpl.java
@@ -80,21 +80,21 @@ public class VoteServiceImpl implements VoteService {
                 return null;
             }
 
-            Map<User, Post> latestPostsByUser = new LinkedHashMap<>();
+            Map<Long, Post> latestPostsByUser = new LinkedHashMap<>();
 
             for (Post post : randomPosts) {
                 User user = post.getUser();
-                if (!latestPostsByUser.containsKey(user)) {
-                    latestPostsByUser.put(user, post);
+                if (!latestPostsByUser.containsKey(user.getId())) {
+                    latestPostsByUser.put(user.getId(), post);
                 }else{
-                    Post latestPost = latestPostsByUser.get(user);
+                    Post latestPost = latestPostsByUser.get(user.getId());
                     if (latestPost.getCreatedAt().isBefore(post.getCreatedAt())) {
-                        latestPostsByUser.put(user, post);
+                        latestPostsByUser.put(user.getId(), post);
                     }
                 }
             }
 
-            cacheShuffledList(voteUserCount, Arrays.asList(randomPosts.toArray()), false);
+            cacheShuffledList(voteUserCount, Arrays.asList(latestPostsByUser.values().toArray()), false);
 
             return getRandomUsersWithPostForVote(voteUserCount);
         }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

BE/feat/image_blur -> back_main


## PR 설명
이미지 블러처리 기능 생성

## ✅ 완료한 기능 명세
### 요구사항

- 유저의 **활발한 게시물 작성을 유도**위해서 게시물에 대한 **이미지 블러기능**을 적용한다.
- 유저는 **최소 24시간 간격**으로 한번의 게시물을 올려야 다른 사람의 게시물을 볼 수 있다.
- 만약 유저가 양면 사진 중 **앞면**만 올리면, 다른 사람의 앞면만 보인다.
- 만약 유저가 양면 사진 중 **뒷면**만 올리면, 다른 사람의 뒷면만 보인다.

*유저가 **24시간 내에 올린 사진(앞|뒤)** or **올린 여부**에 따라 클라이언트에서는 다른 유저의 게시물에 블러처리를 할 수 있어야 한다.*

### 예상 흐름

1. 서버 특정 엔드포인트에 요청
2. 서버에서 24시간 기준으로 해당 요청자 게시물 테이블에서 front back 사진이 있는지 판단
3. true/false 값 반환 

### 문제 정의

- 지금 당장 24시간 내에 올린 게시물이 없더라도, 언제든 앞면, 뒷면 사진을 찍어서 올릴 수 있다. (상태가 언제든지 유동적으로 변함)
- **그럼 유동적으로 변하는 상태를 어떻게 갱신할 것인가? → 이 상태를 “ PostedIn24H “ 라고 하자.**

### ⁉️유동적으로 변하는 이 상태는 어떻게 갱신해야 할까 ⁉️

- 다시 한번 정리하면 이 상태 값은 유저가 게시물을 올리도록 장려하기 위한 이미지 필터링의 기준이다.
- 크게 2가지 방법을 생각할 수 있다.

### 첫번째 방법

> **게시물을 조회하는 상황** ( 친구피드, 전체피드, 나만의 피드 조회 시 )**마다** 내가 마지막에 올린 게시물을 확인해서 상태를 갱신한다.
> 
> 
> ⇒ 게시물을 조회할 때 이 값이 필요하기 때문에 이때 클라이언트에 필요한 값은 맞다.  하지만, 서비스 특성 상 게시물을 조회하는 상황이 엄청 많은데, 그때마다 조회하는 유저가 올린 마지막 피드를 (유저 → 게시물 조인 ) 조회하는 것은 성능적으로 봤을 때 너무 비효율적이다.
> 

### 두번째 방법

> **게시물을 조회할 때마다 x ⇒ 갱신이 필요할 때만 갱신**
그럼 갱신이 필요할 때는 언제일까?
> 

*마지막 갱신이 이루어진 이후에 게시물을 조회하는 상황이라고 가정해보자.*

- 현재상태 : 4가지의 경우의 수
1. 24시간 내에 게시물을 찍지 않음 ⇒ **PostedIn24H [null]**
2. 24시간 내에 게시물을 **앞면만** 찍음 ⇒ **PostedIn24H [front]**
3. 24시간 내에 게시물을 **뒷면만** 찍음 ⇒ **PostedIn24H [back]**
4. 24시간 내에 게시물을 **양면** 찍음 ⇒ **PostedIn24H [front, back]**

- **마지막 갱신이 이루어진 시간 ~ 현재 게시물을 조회하는 시간 사이**에 유저가 게시물을 새로 올렸을 가능성이 있다. **이때 갱신이 필요하다.**
    
    **⇒ ex) 시나리오1 .**
    
    1. 1월 1일 10시에 게시물을 **앞면만** 올림 [front]를 올린 상태로 “PostedIn24H”를 갱신 받음.
    2. 1월 1일 11시에 게시물을 **양면 다** 올림
    3. 1월 1일 12시에 전체 게시물을 조회 
    - 이 유저는 전체 게시물을 조회할 때 **front가 아닌 back, front 사진 모두** 볼 수 있어야 한다.
    - 이렇게 해야 유저가 양면을 모두 찍을 수 있도록 유도할 수 있다.
    
    **⇒ ex) 시니리오2.**
    
    1. 1월 1일 10시에 게시물을 **앞면만** 올림 [front]를 올린 상태로 “PostedIn24H”를 갱신 받음.
    2. 1월 1일 11시에 게시물을 **뒷면만** 올림
    3. 1월 1일 12시에 전체 게시물을 조회 
    - 이 유저는 전체 게시물을 조회할 때 **front가 아닌 back만**  볼 수 있어야 한다.
    - 앞면에서 뒷면을 나중에 올린다고 해도 한번에 둘 다 볼 수 있는 것은 아니다.
    
    **⇒ ex) 시니리오3.**
    
    1. 1월 1일 10시에 게시물을 **양면을** 올림 [front, back]를 올린 상태로 “PostedIn24H”를 갱신 받음.
    2. 1월 1일 11시에 게시물을 **뒷면**만 올림
    3. 1월 1일 12시에 전체 게시물을 조회 
    - 이 유저는 전체 게시물을 조회할 때 **24시간 내에 양면**을 올렸으므로, 양면을  볼 수 있어야 한다.
    - 앞면에서 뒷면을 나중에 올린다고 해도 한번에 둘 다 볼 수 있는 것은 아니다.

- **정리**
    - 그럼 여기서 갱신의 패턴을 찾을 수 있다.
    - 먼저 갱신이 필요한 상태를 정의해보자.
        - (안올림 x == 24시간 지남) **<** (앞면만 == 뒷면만) **<** (양면)

- **결론**
    - 이전에 올리지 않았던 상태에서 조회를 한다면, 반드시 그 사이에 올린 게시물이 있는지 확인하고, 상태를 갱신해야됨.
    - 이전에 앞면만 올렸으면, 게시물을 조회하기 전에 양면을 올렸거나, 24시간이 지났을 수도 있기 때문에 반드시 갱신해야됨 . ⇒ 뒷면도 마찬가지.
    - 양면인 경우는 갱신이 필요없으나, 24시간이 지났다면 갱신이 필요함.

***이러한 경우 양면을 올렸을 때 24시간 동안 조회 쿼리를 최소화할 수 있다. 다만, 클라이언트에서 그 상태를 캐싱해야 한다.***

---

## 클라이언트

**클라이언트의 캐싱 로직을 한번 고려해보자.**

- 먼저 클라이언트는 엔드포인트의 RequestParameter로 상태 갱신을 요청할 수 있다.

```jsx
{{base_url}}/post/read/0?index=0&pageCount=41&**requireRefresh=false**
{{base_url}}/post/read/0?index=0&pageCount=41&**requireRefresh=true**
```

- 클라이언트 요청에 대한
    - **갱신 거부시**
        
        ```jsx
        {
            "status": 202,
            "code": "T002",
            "message": "게시물을 조회를 성공했습니다.",
            "data": {
                "username": "강상호",
                "userId": 252,
                "profileUrl": null,
                "postId": 953,
                "title": "ㅎㅇㅎㅇ",
                "status": "FREETIME",
                "likesCount": 0,
                "postFrontUrl": "https://storageaccount0206.blob.core.windows.net/trueechoblob/20240619035847-resizedFront.jpg",
                "postBackUrl": "https://storageaccount0206.blob.core.windows.net/trueechoblob/20240619035848-resizedBack.jpg",
                "createdAt": "2024-06-19T03:58:48.537436",
                "commentCount": 0,
                "postedIn24H": null,
                "mine": false,
                "friend": true,
                "myLike": false
            }
        }
        ```
        
    
    - **갱신 요청시**
        
        ```jsx
        {
            "status": 202,
            "code": "T002",
            "message": "게시물을 조회를 성공했습니다.",
            "data": {
                "username": "강상호",
                "userId": 252,
                "profileUrl": null,
                "postId": 953,
                "title": "ㅎㅇㅎㅇ",
                "status": "FREETIME",
                "likesCount": 0,
                "postFrontUrl": "https://storageaccount0206.blob.core.windows.net/trueechoblob/20240619035847-resizedFront.jpg",
                "postBackUrl": "https://storageaccount0206.blob.core.windows.net/trueechoblob/20240619035848-resizedBack.jpg",
                "createdAt": "2024-06-19T03:58:48.537436",
                "commentCount": 0,
                "postedIn24H": {
                    "postedFront": true,
                    "postedBack": true,
                    "postedAt": "2024-06-19T04:00:26.709121"
                },
                "myLike": false,
                "mine": false,
                "friend": true
            }
        }
        ```
        

### 현재 프론트 예상 로직

- 클라이언트는 현재 캐싱 상태를 확인한다.
    - 캐싱이 되어 있지 않은 경우  “&**requireRefresh=true” 로 갱신 요청**
        
        ```jsx
        "postedIn24H": {
            "postedFront": true,
            "postedBack": true,
            "postedAt": "2024-06-19T04:00:26.709121"
        },
        ```
        
    - 위의 객체를 캐싱한다.

- 게시물을 조회할 때
    - postedFront, postedBack 필드와 PostedAt 필드를 확인한다.
    
    ### pseudo code
    
    ```jsx
    
    if(postedFront && postedBack && new Date() - new Date(postedAt) <= 24H ){
    	{{base_url}}/post/read/0?index=0&pageCount=41&**requireRefresh=false**
    }else{
    	{{base_url}}/post/read/0?index=0&pageCount=41&**requireRefresh=true
    }**
    ```
    

## 📸 스크린샷

- 갱신 요청 x

![image](https://github.com/TrueEchoProject/TrueEcho_Main/assets/125370420/0ce4c6b2-4424-49a0-885c-09c53a3d9c89)

- 갱신 요청 o

![image](https://github.com/TrueEchoProject/TrueEcho_Main/assets/125370420/04f92624-d251-42e0-831c-d55ed181b952)

